### PR TITLE
chore: AI 모델을 Gemini 3.1 Flash Lite로 교체 및 마크다운 bold 렌더링 수정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,11 @@ Font size preference is persisted in localStorage via `useFontSize` → `useLoca
 ### Adding Flashcard Questions
 
 Add entries to the relevant file in `src/data/`. Each card follows:
+
 ```typescript
 { id: number, category: Category, question: string, answer: string }
 ```
+
 IDs must be unique within the file. `questions.ts` auto-includes the new data via spread.
 
 ### Adding a New Category
@@ -66,8 +68,7 @@ IDs must be unique within the file. `questions.ts` auto-includes the new data vi
 ### AI Chat API
 
 - Route: `src/app/api/chat/route.ts`
-- Model: `gemma-3-27b-it` via `@google/genai` SDK (`GoogleGenAI`)
+- Model: `gemini-3.1-flash-lite-preview` via `@google/genai` SDK (`GoogleGenAI`)
 - Requires env var: `GEMINI_API_KEY`
-- **주의:** Gemma 모델은 `systemInstruction` config 파라미터 미지원 → system prompt를 `contents` 배열 첫 번째 user/model turn으로 주입
 - Hook: `src/hooks/useAIChat.ts` — localStorage로 메시지 저장, 최대 50개 유지
 - 카드 컨텍스트(`cardContext`)가 전달되면 현재 플래시카드 내용을 system prompt에 포함

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - 답변 슬라이드 애니메이션으로 공개
 - 7개 카테고리 필터 (CS, HTML/CSS, JavaScript, TypeScript, React, 자료구조, 알고리즘)
 - 랜덤 셔플 모드
-- AI 문답 기능 (Gemma 3 27B 기반, 현재 카드 컨텍스트 연동)
+- AI 문답 기능 (Gemini 3.1 Flash Lite 기반, 현재 카드 컨텍스트 연동)
 - 다크모드 / 라이트모드
 - 글자 크기 조절 (소 / 중 / 대)
 - 키보드 단축키 (← →, Space / Enter)
@@ -18,17 +18,17 @@
 
 ## 기술 스택
 
-| 항목       | 기술                            |
-| ---------- | ------------------------------- |
-| 프레임워크 | Next.js 16 (App Router)         |
-| 스타일링   | Tailwind CSS v4                 |
-| 애니메이션 | motion                          |
-| 스와이프   | react-swipeable                 |
-| 테마       | next-themes                     |
-| PWA        | @serwist/next                   |
-| 아이콘     | lucide-react                    |
-| 상태관리   | React Context + useReducer      |
-| AI         | Google Gemini API (Gemma 3 27B) |
+| 항목       | 기술                                      |
+| ---------- | ----------------------------------------- |
+| 프레임워크 | Next.js 16 (App Router)                   |
+| 스타일링   | Tailwind CSS v4                           |
+| 애니메이션 | motion                                    |
+| 스와이프   | react-swipeable                           |
+| 테마       | next-themes                               |
+| PWA        | @serwist/next                             |
+| 아이콘     | lucide-react                              |
+| 상태관리   | React Context + useReducer                |
+| AI         | Google Gemini API (Gemini 3.1 Flash Lite) |
 
 ## 시작하기
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
-    "react-swipeable": "^7.0.2"
+    "react-swipeable": "^7.0.2",
+    "rehype-raw": "^7.0.0"
   },
   "devDependencies": {
     "@serwist/next": "^9.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-swipeable:
         specifier: ^7.0.2
         version: 7.0.2(react@19.2.3)
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
     devDependencies:
       '@serwist/next':
         specifier: ^9.5.6
@@ -1138,6 +1141,10 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
     engines: {node: '>= 0.4'}
@@ -1485,11 +1492,26 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -1499,6 +1521,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2100,6 +2125,9 @@ packages:
   parse-statements@1.0.11:
     resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2201,6 +2229,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -2525,11 +2556,17 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -3625,6 +3662,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  entities@6.0.1: {}
+
   es-abstract@1.24.1:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -4135,6 +4174,37 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.0
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -4155,9 +4225,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   hermes-estree@0.25.1: {}
 
@@ -4166,6 +4254,8 @@ snapshots:
       hermes-estree: 0.25.1
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -4888,6 +4978,10 @@ snapshots:
 
   parse-statements@1.0.11: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -5004,6 +5098,12 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
 
   remark-parse@11.0.0:
     dependencies:
@@ -5456,6 +5556,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -5465,6 +5570,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,7 +1,8 @@
-import { GoogleGenAI } from "@google/genai";
 import { NextRequest, NextResponse } from "next/server";
 
-const MODEL = "gemma-3-27b-it";
+import { GoogleGenAI } from "@google/genai";
+
+const MODEL = "gemini-3.1-flash-lite-preview";
 
 const BASE_SYSTEM_PROMPT = `당신은 프론트엔드 개발자 면접 준비를 돕는 AI 튜터입니다.
 JavaScript, React, CSS, CS, 자료구조, 알고리즘 등 프론트엔드 관련 개념에 대해 명확하고 이해하기 쉽게 설명해 주세요.
@@ -28,7 +29,8 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json();
-  const message = typeof body.message === "string" ? body.message.slice(0, 500) : "";
+  const message =
+    typeof body.message === "string" ? body.message.slice(0, 500) : "";
   const history: HistoryItem[] = Array.isArray(body.history)
     ? body.history
         .slice(-20)
@@ -39,7 +41,10 @@ export async function POST(req: NextRequest) {
             typeof (h as HistoryItem).role === "string" &&
             typeof (h as HistoryItem).text === "string"
         )
-        .map((h: HistoryItem) => ({ role: h.role, text: h.text.slice(0, 2000) }))
+        .map((h: HistoryItem) => ({
+          role: h.role,
+          text: h.text.slice(0, 2000),
+        }))
     : [];
   const cardContext: CardContext | undefined =
     body.cardContext &&
@@ -62,10 +67,7 @@ export async function POST(req: NextRequest) {
     ? `${BASE_SYSTEM_PROMPT}\n\n현재 사용자가 학습 중인 플래시카드:\n질문: ${cardContext.question}\n답변: ${cardContext.answer}`
     : BASE_SYSTEM_PROMPT;
 
-  // Gemma는 systemInstruction 미지원 → 첫 turn에 주입
   const contents = [
-    { role: "user" as const, parts: [{ text: systemPrompt }] },
-    { role: "model" as const, parts: [{ text: "알겠습니다. 프론트엔드 면접 준비를 도와드리겠습니다." }] },
     ...(history ?? []).map((h) => ({
       role: h.role as "user" | "model",
       parts: [{ text: h.text }],
@@ -79,6 +81,7 @@ export async function POST(req: NextRequest) {
       model: MODEL,
       contents,
       config: {
+        systemInstruction: systemPrompt,
         maxOutputTokens: 1024,
         temperature: 0.7,
       },

--- a/src/components/ai/AIChatMessage.tsx
+++ b/src/components/ai/AIChatMessage.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import ReactMarkdown from "react-markdown";
-
+import type { ChatMessage } from "@/hooks/useAIChat";
 import type { FontSizeKey } from "@/lib/constants";
 import { FONT_SIZE_PRESETS } from "@/lib/constants";
-import type { ChatMessage } from "@/hooks/useAIChat";
+
+import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+
+// CommonMark 파서가 **'text'** 같은 패턴을 bold로 인식하지 못하는 문제 보완
+function preprocessBold(content: string): string {
+  return content.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+}
 
 interface AIChatMessageProps {
   message: ChatMessage;
@@ -28,6 +34,7 @@ export function AIChatMessage({ message, fontSize }: AIChatMessageProps) {
           <span className="whitespace-pre-line">{message.content}</span>
         ) : (
           <ReactMarkdown
+            rehypePlugins={[rehypeRaw]}
             components={{
               p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
               strong: ({ children }) => (
@@ -66,7 +73,7 @@ export function AIChatMessage({ message, fontSize }: AIChatMessageProps) {
               ),
             }}
           >
-            {message.content}
+            {preprocessBold(message.content)}
           </ReactMarkdown>
         )}
       </div>

--- a/src/components/ai/AIChatPanel.tsx
+++ b/src/components/ai/AIChatPanel.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { AnimatePresence, motion } from "motion/react";
-import { Send, Sparkles, Trash2, X } from "lucide-react";
 
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { useFlashcard } from "@/context/FlashcardContext";
 import { useAIChat } from "@/hooks/useAIChat";
 import { useFontSize } from "@/hooks/useFontSize";
 import type { FontSizeKey } from "@/lib/constants";
 import { FONT_SIZE_PRESETS } from "@/lib/constants";
-import { useFlashcard } from "@/context/FlashcardContext";
-import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+
+import { Send, Sparkles, Trash2, X } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 
 import { AIChatMessage } from "./AIChatMessage";
 
@@ -21,14 +22,8 @@ interface AIChatPanelProps {
 export function AIChatPanel({ isOpen, onClose }: AIChatPanelProps) {
   const { currentCard } = useFlashcard();
   const { fontSize } = useFontSize();
-  const {
-    messages,
-    isLoading,
-    error,
-    sendMessage,
-    clearMessages,
-    clearError,
-  } = useAIChat();
+  const { messages, isLoading, error, sendMessage, clearMessages, clearError } =
+    useAIChat();
   const [input, setInput] = useState("");
   const [showConfirm, setShowConfirm] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -98,7 +93,10 @@ export function AIChatPanel({ isOpen, onClose }: AIChatPanelProps) {
             <div className="flex items-center gap-2">
               <span
                 className="flex h-7 w-7 items-center justify-center rounded-lg text-white"
-                style={{ background: "linear-gradient(135deg, #8b5cf6, #ec4899, #f97316)" }}
+                style={{
+                  background:
+                    "linear-gradient(135deg, #8b5cf6, #ec4899, #f97316)",
+                }}
               >
                 <Sparkles size={15} strokeWidth={1.5} />
               </span>
@@ -143,7 +141,8 @@ export function AIChatPanel({ isOpen, onClose }: AIChatPanelProps) {
                   <div
                     className="flex h-12 w-12 items-center justify-center rounded-full text-white"
                     style={{
-                      background: "linear-gradient(135deg, #8b5cf6, #ec4899, #f97316)",
+                      background:
+                        "linear-gradient(135deg, #8b5cf6, #ec4899, #f97316)",
                     }}
                   >
                     <Sparkles size={22} strokeWidth={1.5} />
@@ -237,7 +236,10 @@ export function AIChatPanel({ isOpen, onClose }: AIChatPanelProps) {
                 type="submit"
                 disabled={!input.trim() || isLoading}
                 className="flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-xl text-white shadow-sm transition-all hover:opacity-90 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40"
-                style={{ background: "linear-gradient(135deg, #8b5cf6, #ec4899, #f97316)" }}
+                style={{
+                  background:
+                    "linear-gradient(135deg, #8b5cf6, #ec4899, #f97316)",
+                }}
                 aria-label="전송"
               >
                 <Send size={17} />
@@ -245,10 +247,12 @@ export function AIChatPanel({ isOpen, onClose }: AIChatPanelProps) {
             </form>
             <div className="mt-1.5 flex items-center justify-between">
               <span className="text-[10px] text-neutral-400 dark:text-neutral-500">
-                Gemma 3 27B
+                Gemini 3.1 Flash Lite
               </span>
               {input.length > 0 ? (
-                <span className={`text-[10px] ${input.length >= MAX_INPUT ? "text-red-400" : "text-neutral-400 dark:text-neutral-500"}`}>
+                <span
+                  className={`text-[10px] ${input.length >= MAX_INPUT ? "text-red-400" : "text-neutral-400 dark:text-neutral-500"}`}
+                >
                   {input.length}/{MAX_INPUT}
                 </span>
               ) : (


### PR DESCRIPTION
- Gemma 3 27B → Gemini 3.1 Flash Lite Preview로 모델 변경
- systemInstruction config 방식으로 system prompt 전달 변경
- rehype-raw 추가 및 **bold** 전처리로 CommonMark 파싱 이슈 해결
- 모델명 표기 일괄 업데이트 (CLAUDE.md, README.md, AIChatPanel)
- .env.local.example 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * AI 모델을 Gemini 3.1 Flash Lite로 업그레이드하여 성능과 응답성 개선
  * 채팅 메시지에서 마크다운 렌더링 향상 및 원본 HTML 처리 지원 추가
  * 굵은 텍스트 서식 자동 처리 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->