### PR TITLE
chore: AI 모델을 Gemma 3 27B로 복구

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ IDs must be unique within the file. `questions.ts` auto-includes the new data vi
 ### AI Chat API
 
 - Route: `src/app/api/chat/route.ts`
-- Model: `gemini-3.1-flash-lite-preview` via `@google/genai` SDK (`GoogleGenAI`)
+- Model: `gemma-3-27b-it` via `@google/genai` SDK (`GoogleGenAI`)
 - Requires env var: `GEMINI_API_KEY`
+- **주의:** Gemma 모델은 `systemInstruction` config 파라미터 미지원 → system prompt를 `contents` 배열 첫 번째 user/model turn으로 주입
 - Hook: `src/hooks/useAIChat.ts` — localStorage로 메시지 저장, 최대 50개 유지
 - 카드 컨텍스트(`cardContext`)가 전달되면 현재 플래시카드 내용을 system prompt에 포함

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - 답변 슬라이드 애니메이션으로 공개
 - 7개 카테고리 필터 (CS, HTML/CSS, JavaScript, TypeScript, React, 자료구조, 알고리즘)
 - 랜덤 셔플 모드
-- AI 문답 기능 (Gemini 3.1 Flash Lite 기반, 현재 카드 컨텍스트 연동)
+- AI 문답 기능 (Gemma 3 27B 기반, 현재 카드 컨텍스트 연동)
 - 다크모드 / 라이트모드
 - 글자 크기 조절 (소 / 중 / 대)
 - 키보드 단축키 (← →, Space / Enter)
@@ -18,17 +18,17 @@
 
 ## 기술 스택
 
-| 항목       | 기술                                      |
-| ---------- | ----------------------------------------- |
-| 프레임워크 | Next.js 16 (App Router)                   |
-| 스타일링   | Tailwind CSS v4                           |
-| 애니메이션 | motion                                    |
-| 스와이프   | react-swipeable                           |
-| 테마       | next-themes                               |
-| PWA        | @serwist/next                             |
-| 아이콘     | lucide-react                              |
-| 상태관리   | React Context + useReducer                |
-| AI         | Google Gemini API (Gemini 3.1 Flash Lite) |
+| 항목       | 기술                            |
+| ---------- | ------------------------------- |
+| 프레임워크 | Next.js 16 (App Router)         |
+| 스타일링   | Tailwind CSS v4                 |
+| 애니메이션 | motion                          |
+| 스와이프   | react-swipeable                 |
+| 테마       | next-themes                     |
+| PWA        | @serwist/next                   |
+| 아이콘     | lucide-react                    |
+| 상태관리   | React Context + useReducer      |
+| AI         | Google Gemini API (Gemma 3 27B) |
 
 ## 시작하기
 

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { GoogleGenAI } from "@google/genai";
 
-const MODEL = "gemini-3.1-flash-lite-preview";
+const MODEL = "gemma-3-27b-it";
 
 const BASE_SYSTEM_PROMPT = `당신은 프론트엔드 개발자 면접 준비를 돕는 AI 튜터입니다.
 JavaScript, React, CSS, CS, 자료구조, 알고리즘 등 프론트엔드 관련 개념에 대해 명확하고 이해하기 쉽게 설명해 주세요.
@@ -67,7 +67,13 @@ export async function POST(req: NextRequest) {
     ? `${BASE_SYSTEM_PROMPT}\n\n현재 사용자가 학습 중인 플래시카드:\n질문: ${cardContext.question}\n답변: ${cardContext.answer}`
     : BASE_SYSTEM_PROMPT;
 
+  // Gemma는 systemInstruction 미지원 → 첫 turn에 주입
   const contents = [
+    { role: "user" as const, parts: [{ text: systemPrompt }] },
+    {
+      role: "model" as const,
+      parts: [{ text: "알겠습니다. 프론트엔드 면접 준비를 도와드리겠습니다." }],
+    },
     ...(history ?? []).map((h) => ({
       role: h.role as "user" | "model",
       parts: [{ text: h.text }],
@@ -81,7 +87,6 @@ export async function POST(req: NextRequest) {
       model: MODEL,
       contents,
       config: {
-        systemInstruction: systemPrompt,
         maxOutputTokens: 1024,
         temperature: 0.7,
       },

--- a/src/components/ai/AIChatPanel.tsx
+++ b/src/components/ai/AIChatPanel.tsx
@@ -247,7 +247,7 @@ export function AIChatPanel({ isOpen, onClose }: AIChatPanelProps) {
             </form>
             <div className="mt-1.5 flex items-center justify-between">
               <span className="text-[10px] text-neutral-400 dark:text-neutral-500">
-                Gemini 3.1 Flash Lite
+                Gemma 3 27B
               </span>
               {input.length > 0 ? (
                 <span


### PR DESCRIPTION
- Gemini 3.1 Flash Lite Preview 서버 불안정으로 인한 롤백
- systemInstruction → contents 첫 turn 주입 방식으로 복구 (Gemma 미지원)
- 모델명 표기 일괄 복구 (route.ts, AIChatPanel, README.md, CLAUDE.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **문서 업데이트**
  * README의 AI 문답 기능 설명 및 기술 스택 정보를 업데이트했습니다.

* **Chores**
  * AI 챗 서비스의 백엔드 모델을 변경했습니다.
  * 채팅 패널의 AI 모델 표시 라벨을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->